### PR TITLE
Documentation resolve #59

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,12 @@
 
 <div>
 <h2>Getting Started</h2>
-<p>This is a French to English translation model.</p>
+<p>This example implements a French to English translation model.</p>
 
-<p>Also check out this blog post on Medium: <a href="https://towardsdatascience.com/transformers-in-action-attention-is-all-you-need-ac10338a023a">Transformers in Action: Attention Is All You Need</a></p>
+<p>Check out these blog posts on Medium:
+
+- <a href="https://towardsdatascience.com/transformers-in-action-attention-is-all-you-need-ac10338a023a">Transformers in Action: Attention Is All You Need</a></p>
+- <a href="https://towardsdatascience.com/rethinking-thinking-how-do-attention-mechanisms-actually-work-a6f67d313f99">Rethinking Thinking: How Do Attention Mechanisms Actually Work?</a></p>
 
 <b>Note</b>: The <code>data_loader</code> and <code>training</code> modules are still under development and you may 
 want to use your own training and input pipeline. However, 
@@ -97,13 +100,22 @@ trainer.fit(model, data)
 
 - [x] Support Tensorflow
 - [ ] Extensive documentation
+  - <a href="https://github.com/tensorops/TransformerX/issues/30">Documentation</a>
+  - Examples (Colab, etc.)
+  - Add more contents to the <a href="https://github.com/tensorops/TransformerX/blob/master/README.md">README.md</a>
 - [ ] Support Pytorch and JAX
 - [ ] More layers
+    - <a href="https://github.com/tensorops/TransformerX/issues/44">Attention layers</a>
+  - <a href="https://github.com/tensorops/TransformerX/issues/42">Residual and residual gate layers</a>
+  - <a href="https://github.com/tensorops/TransformerX/issues/41">Embedding layers</a>
 </div>
 <div>
 <h2>Contribution</h2>
 
 Contributions are what make the open source community such an amazing place to learn, inspire, and create. Any contributions you make are <b>greatly appreciated</b>.
+
+In case you want to get ideas or just work on a ready-to-solve issue, please check out issues with the label `issue list`.
+Here is  a list of lists: https://github.com/tensorops/TransformerX/issues?q=is%3Aissue+is%3Aopen+label%3A%22issue+list%22
 
 If you have a suggestion that would make this better, please fork the repo and create a pull request. You can also simply open an issue with the tag "enhancement" or "bug". 
 

--- a/transformerx/layers/positional_encoding.py
+++ b/transformerx/layers/positional_encoding.py
@@ -58,7 +58,7 @@ class AbsolutePositionalEncoding(tf.keras.layers.Layer):
     """
 
     def __init__(self, depth, dropout_rate=0, max_len=1000):
-        super().__init__()
+        super(AbsolutePositionalEncoding, self).__init__()
         self.dropout = tf.keras.layers.Dropout(dropout_rate)
         # Create a long enough P
 
@@ -79,3 +79,15 @@ class AbsolutePositionalEncoding(tf.keras.layers.Layer):
         # print("self.P[:, : x.shape[1], :]: ", self.P[:, : x.shape[1], :].shape)
         X = X + self.P[:, : X.shape[1], :]
         return self.dropout(X, **kwargs)
+
+def exists(val):
+    return val is not None
+
+class FixedPositionalEncoding(tf.keras.layers.Layer):
+    def __init__(self, dim):
+        super(FixedPositionalEncoding, self).__init__()
+        inv_freq = 1. / (10000 ** (np.arange(0, dim, 2).__float__() / dim))
+
+    def call(self, inputs, pos=None, seq_dim=1, offset=0, **kwargs):
+        if not exists(pos):
+            pos = np.arange(input.shape[seq_dim])

--- a/transformerx/layers/positional_encoding.py
+++ b/transformerx/layers/positional_encoding.py
@@ -1,6 +1,8 @@
 import numpy as np
 import tensorflow as tf
 
+from transformerx.utils import exists
+
 
 class AbsolutePositionalEncoding(tf.keras.layers.Layer):
     """Compute absolute positional encoding object [1]_.
@@ -80,8 +82,6 @@ class AbsolutePositionalEncoding(tf.keras.layers.Layer):
         X = X + self.P[:, : X.shape[1], :]
         return self.dropout(X, **kwargs)
 
-def exists(val):
-    return val is not None
 
 class FixedPositionalEncoding(tf.keras.layers.Layer):
     def __init__(self, dim):

--- a/transformerx/layers/positional_encoding.py
+++ b/transformerx/layers/positional_encoding.py
@@ -96,11 +96,13 @@ class RelativePositionEmbedding(tf.keras.layers.Layer):
     (2017). Attention Is All You Need. arXiv. https://doi.org/10.48550/arXiv.1706.03762
     """
 
-    def __init__(self, scale, causal = False, num_buckets = 32, max_distance = 128, heads = 8):
+    def __init__(self, scale, causal=False, num_buckets=32, max_distance=128, heads=8):
         super().__init__()
         self.scale = scale
         self.causal = causal
         self.num_buckets = num_buckets
         self.max_distance = max_distance
         self.relative_attention_bias = tf.keras.layers.Embedding(num_buckets, heads)
-    pass
+
+    def call(self):
+        pass

--- a/transformerx/layers/positional_encoding.py
+++ b/transformerx/layers/positional_encoding.py
@@ -83,11 +83,24 @@ class AbsolutePositionalEncoding(tf.keras.layers.Layer):
         return self.dropout(X, **kwargs)
 
 
-class FixedPositionalEncoding(tf.keras.layers.Layer):
-    def __init__(self, dim):
-        super(FixedPositionalEncoding, self).__init__()
-        inv_freq = 1. / (10000 ** (np.arange(0, dim, 2).__float__() / dim))
+class RelativePositionEmbedding(tf.keras.layers.Layer):
+    """Create a relative positional embedding as in [2]_.
 
-    def call(self, inputs, pos=None, seq_dim=1, offset=0, **kwargs):
-        if not exists(pos):
-            pos = np.arange(input.shape[seq_dim])
+
+    References
+    ----------
+    .. [1] Peter Shaw, Jakob Uszkoreit, Ashish Vaswani (2018), Self-Attention with Relative Position
+    Representations, https://doi.org/10.48550/arXiv.1803.02155
+
+    .. [2] Vaswani, A., Shazeer, N., Parmar, N., Uszkoreit, J., Jones, L., Gomez, A. N., Kaiser, L., & Polosukhin, I.
+    (2017). Attention Is All You Need. arXiv. https://doi.org/10.48550/arXiv.1706.03762
+    """
+
+    def __init__(self, scale, causal = False, num_buckets = 32, max_distance = 128, heads = 8):
+        super().__init__()
+        self.scale = scale
+        self.causal = causal
+        self.num_buckets = num_buckets
+        self.max_distance = max_distance
+        self.relative_attention_bias = tf.keras.layers.Embedding(num_buckets, heads)
+    pass

--- a/transformerx/layers/transformer_decoder.py
+++ b/transformerx/layers/transformer_decoder.py
@@ -80,7 +80,52 @@ class TransformerDecoder(tf.keras.layers.Layer):
         return [enc_outputs, enc_valid_lens, [None] * self.n_blocks]
 
     def call(self, X, state, **kwargs):
+        """Forward call of the Transformer decoder.
 
+        Parameters
+        ----------
+        X : tf.Tensor
+            Input tensor with shape (batch_size, no. of queries or key-value pairs, depth).
+        state : List
+            List of decoder state tensors.
+        **kwargs
+            Other keyword arguments.
+
+        Returns
+        -------
+        output : tf.Tensor
+            Output tensor with shape (batch_size, no. of queries or key-value pairs, depth).
+        state : List
+            Updated list of decoder state tensors.
+
+        Examples
+        --------
+        >>> # Initialize a TransformerDecoder with a vocabulary size of 1000 and a depth of 512
+        >>> decoder = TransformerDecoder(
+        ...    vocab_size=1000,
+        ...    depth=512,
+        ...    norm_shape=(512,),
+        ...    n_blocks=6,
+        ...    dropout=0.2
+        >>> )
+
+        >>> # Define the input sequence, with batch size of 2 and sequence length of 10
+        >>> inputs = tf.random.uniform((2, 10), minval=0, maxval=1000, dtype=tf.int32)
+
+        >>> # Define the initial state of the decoder, which should be the output from the encoder
+        >>> # and the valid sequence lengths from the encoder
+        >>> enc_outputs = tf.random.normal((2, 10, 512))
+        >>> enc_valid_lens = tf.constant([10, 5], dtype=tf.int32)
+        >>> initial_state = decoder.init_state(enc_outputs, enc_valid_lens)
+
+        >>> # Call the decoder to get the output and the updated state
+        >>> output, state = decoder(inputs, initial_state)
+
+        >>> # The output will be a tensor of shape (2, 10, 1000) containing the predicted
+        >>> # probabilities for each of the input tokens at each timestep
+        >>> # The state will be a tuple containing the encoder outputs, the encoder valid lengths,
+        >>> # and a list of attention weights for each block in the decoder
+        """
 
         X = self.pos_encoding(
                 self.embedding(X) * tf.math.sqrt(tf.cast(self.depth, dtype=tf.float32)),

--- a/transformerx/layers/transformer_decoder.py
+++ b/transformerx/layers/transformer_decoder.py
@@ -5,7 +5,48 @@ from transformerx.layers.transformer_decoder_block import TransformerDecoderBloc
 
 
 class TransformerDecoder(tf.keras.layers.Layer):
-    """Transformer decoder that encompasses one or more TransformerDecoderBlock blocks."""
+    """Transformer decoder that encompasses one or more TransformerDecoderBlock blocks.
+
+    Transformer decoder that encompasses one or more TransformerDecoderBlock blocks.
+
+    The TransformerDecoder processes the input sequences and produces the output sequences.
+    It also generates attention weights for each of the two attention layers in each of the
+    TransformerDecoderBlock blocks.
+
+    Parameters
+    ----------
+    vocab_size : int
+        Vocabulary size.
+    depth : int
+        Dimension of each input sequence.
+    norm_shape : str
+        Shape of the normalization layer.
+    ffn_num_hiddens : int
+        Number of hidden units in the feed-forward network.
+    num_heads : int
+        Number of attention heads.
+    n_blocks : int
+        Number of encoder blocks.
+    dropout : float
+        Dropout rate.
+
+    Attributes
+    ----------
+    depth : int
+        The depth (i.e., number of channels) of the input and output representations.
+    n_blocks : int
+        The number of TransformerDecoderBlock blocks in the decoder.
+    embedding : tf.keras.layers.Embedding
+        The embedding layer that maps the input sequences to their input representations.
+    pos_encoding : AbsolutePositionalEncoding
+        The absolute positional encoding layer that adds position information to the input
+        representations.
+    blocks : List[TransformerDecoderBlock]
+        The list of TransformerDecoderBlock blocks that process the input sequences.
+    dense : tf.keras.layers.Dense
+        The dense layer that maps the output representations to the output sequences.
+    """
+
 
     def __init__(
             self,
@@ -39,6 +80,53 @@ class TransformerDecoder(tf.keras.layers.Layer):
         return [enc_outputs, enc_valid_lens, [None] * self.n_blocks]
 
     def call(self, X, state, **kwargs):
+        """Forward call of the Transformer decoder.
+
+        Parameters
+        ----------
+        X : tf.Tensor
+            Input tensor with shape (batch_size, no. of queries or key-value pairs, depth).
+        state : List
+            List of decoder state tensors.
+        **kwargs
+            Other keyword arguments.
+
+        Returns
+        -------
+        output : tf.Tensor
+            Output tensor with shape (batch_size, no. of queries or key-value pairs, depth).
+        state : List
+            Updated list of decoder state tensors.
+
+        Examples
+        --------
+        >>> # Initialize a TransformerDecoder with a vocabulary size of 1000 and a depth of 512
+        >>> decoder = TransformerDecoder(
+        ...    vocab_size=1000,
+        ...    depth=512,
+        ...    norm_shape=(512,),
+        ...    n_blocks=6,
+        ...    dropout=0.2
+        >>> )
+
+        >>> # Define the input sequence, with batch size of 2 and sequence length of 10
+        >>> inputs = tf.random.uniform((2, 10), minval=0, maxval=1000, dtype=tf.int32)
+
+        >>> # Define the initial state of the decoder, which should be the output from the encoder
+        >>> # and the valid sequence lengths from the encoder
+        >>> enc_outputs = tf.random.normal((2, 10, 512))
+        >>> enc_valid_lens = tf.constant([10, 5], dtype=tf.int32)
+        >>> initial_state = decoder.init_state(enc_outputs, enc_valid_lens)
+
+        >>> # Call the decoder to get the output and the updated state
+        >>> output, state = decoder(inputs, initial_state)
+
+        >>> # The output will be a tensor of shape (2, 10, 1000) containing the predicted
+        >>> # probabilities for each of the input tokens at each timestep
+        >>> # The state will be a tuple containing the encoder outputs, the encoder valid lengths,
+        >>> # and a list of attention weights for each block in the decoder
+        """
+
         X = self.pos_encoding(
                 self.embedding(X) * tf.math.sqrt(tf.cast(self.depth, dtype=tf.float32)),
                 **kwargs,

--- a/transformerx/layers/transformer_decoder.py
+++ b/transformerx/layers/transformer_decoder.py
@@ -80,52 +80,7 @@ class TransformerDecoder(tf.keras.layers.Layer):
         return [enc_outputs, enc_valid_lens, [None] * self.n_blocks]
 
     def call(self, X, state, **kwargs):
-        """Forward call of the Transformer decoder.
 
-        Parameters
-        ----------
-        X : tf.Tensor
-            Input tensor with shape (batch_size, no. of queries or key-value pairs, depth).
-        state : List
-            List of decoder state tensors.
-        **kwargs
-            Other keyword arguments.
-
-        Returns
-        -------
-        output : tf.Tensor
-            Output tensor with shape (batch_size, no. of queries or key-value pairs, depth).
-        state : List
-            Updated list of decoder state tensors.
-
-        Examples
-        --------
-        >>> # Initialize a TransformerDecoder with a vocabulary size of 1000 and a depth of 512
-        >>> decoder = TransformerDecoder(
-        ...    vocab_size=1000,
-        ...    depth=512,
-        ...    norm_shape=(512,),
-        ...    n_blocks=6,
-        ...    dropout=0.2
-        >>> )
-
-        >>> # Define the input sequence, with batch size of 2 and sequence length of 10
-        >>> inputs = tf.random.uniform((2, 10), minval=0, maxval=1000, dtype=tf.int32)
-
-        >>> # Define the initial state of the decoder, which should be the output from the encoder
-        >>> # and the valid sequence lengths from the encoder
-        >>> enc_outputs = tf.random.normal((2, 10, 512))
-        >>> enc_valid_lens = tf.constant([10, 5], dtype=tf.int32)
-        >>> initial_state = decoder.init_state(enc_outputs, enc_valid_lens)
-
-        >>> # Call the decoder to get the output and the updated state
-        >>> output, state = decoder(inputs, initial_state)
-
-        >>> # The output will be a tensor of shape (2, 10, 1000) containing the predicted
-        >>> # probabilities for each of the input tokens at each timestep
-        >>> # The state will be a tuple containing the encoder outputs, the encoder valid lengths,
-        >>> # and a list of attention weights for each block in the decoder
-        """
 
         X = self.pos_encoding(
                 self.embedding(X) * tf.math.sqrt(tf.cast(self.depth, dtype=tf.float32)),

--- a/transformerx/layers/transformer_decoder.py
+++ b/transformerx/layers/transformer_decoder.py
@@ -16,19 +16,25 @@ class TransformerDecoder(tf.keras.layers.Layer):
     Parameters
     ----------
     vocab_size : int
-        Vocabulary size.
+        Vocabulary size. The size of the vocabulary used by the Transformer decoder. This is used to determine the
+        size of the input tensor and the output tensor of the call method.
     depth : int
-        Dimension of each input sequence.
+        Dimension of each input sequence. The depth of the input tensor and the output tensor of the call method.
+        This is also the size of the hidden states of the Transformer decoder blocks.
     norm_shape : str
-        Shape of the normalization layer.
+        Shape of the normalization layers in the Transformer decoder blocks. This is a tuple of three integers,
+        specifying the number of dimensions to normalize over for the first, second, and third normalization layers,
+        respectively.
     ffn_num_hiddens : int
-        Number of hidden units in the feed-forward network.
+        Number of hidden units in the feed-forward neural network layers of the Transformer decoder blocks.
     num_heads : int
-        Number of attention heads.
+        Number of attention heads of the Transformer decoder blocks.
     n_blocks : int
-        Number of encoder blocks.
+        Number of encoder blocks in the Transformer decoder.
     dropout : float
-        Dropout rate.
+        The dropout rate to use for the dropout layers in the Transformer decoder blocks. This value is used to
+        determine the strength of regularization. A higher dropout rate means that more nodes are dropped out during
+        training, which can help prevent overfitting.
 
     Attributes
     ----------
@@ -85,11 +91,22 @@ class TransformerDecoder(tf.keras.layers.Layer):
         Parameters
         ----------
         X : tf.Tensor
-            Input tensor with shape (batch_size, no. of queries or key-value pairs, depth).
+            Input tensor with shape (batch_size, no. of queries or key-value pairs, depth). This tensor is used to
+            compute the output of the Transformer decoder.
         state : List
-            List of decoder state tensors.
+            List of decoder state tensors. This is a list of three elements:
+                - enc_outputs: The outputs of the Transformer encoder, of shape (batch_size, max_seq_len, depth).
+                This tensor is used to compute the attention weights for the encoder-decoder attention layer in the
+                Transformer decoder blocks.
+                - enc_valid_lens: The valid lengths of the input sequence to the Transformer encoder, of shape
+                (batch_size,) or (batch_size, max_seq_len). This tensor is used to mask the outputs of the Transformer
+                encoder so that only the valid parts of the sequence are used in the attention computations.
+                - state: A list of length n_blocks, where each element is the state of the corresponding Transformer
+                decoder block. This state is used to carry over information from previous time steps when computing the
+                output of the Transformer decoder blocks.
         **kwargs
-            Other keyword arguments.
+            Additional keyword arguments that can be passed to the Transformer decoder blocks. This can include
+            arguments such as the attention mask and the mask for the masked language model.
 
         Returns
         -------

--- a/transformerx/utils.py
+++ b/transformerx/utils.py
@@ -38,3 +38,7 @@ def use_device(device):
         os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
     else:
         pass
+
+
+def exists(val):
+    return val is not None


### PR DESCRIPTION
I have added documentation for the `TransformerDecoder` class and its `call` method. The documentation includes a description of the class and its attributes, a description of the `call` method and its arguments and return values, and examples of how to use the class and its method.

Please review and let me know if any changes are needed.