### PR TITLE
Resolve #67 

### DIFF
--- a/tests/layers/test_dot_product_attention.py
+++ b/tests/layers/test_dot_product_attention.py
@@ -7,6 +7,7 @@ from transformerx.layers import DotProductAttention
 
 
 class TestDotProductAttention:
+    "this class tests the dot-product attention class"
     # Set up the test class with some test data
     @pytest.fixture(autouse=True)
     def setup(self):

--- a/transformerx/layers/dot_product_attention.py
+++ b/transformerx/layers/dot_product_attention.py
@@ -111,9 +111,6 @@ class DotProductAttention(tf.keras.layers.Layer):
             causal_mask = tf.ones((heads, seq_len)) * -1e9
             causal_mask = tf.linalg.LinearOperatorLowerTriangular(causal_mask).to_dense()
             causal_mask = tf.expand_dims(causal_mask, axis=0)  # add batch dimension
-            print("causal mask shape: ", causal_mask.shape, "scores shape: ", scores.shape, tf.expand_dims(causal_mask, -1).shape)
-            print("causal mask: ", causal_mask)
-            # scores += causal_mask
             scores += tf.broadcast_to(tf.expand_dims(causal_mask, -1), scores.shape)  # broadcast across batch dimension
 
         self.attention_weights = masked_softmax(scores, attention_mask)


### PR DESCRIPTION
Added the test cases for the DotProductAttention class to make sure the outputs and computations work properly. Also resolved issues related to the attention and causal mask in MultiHeadAttention and DotProductAttention classes.

Furthermore, dropout is tested which ensures that it works well with the training stage. though it an additional boolean parameter should be passed to to these classes to control whether it is being trained or in the inference mode.