### PR TITLE
Resolve #73

### DIFF
--- a/transformerx/layers/positionwise_ffn.py
+++ b/transformerx/layers/positionwise_ffn.py
@@ -66,8 +66,63 @@ import tensorflow as tf
 #
 
 
-
 class PositionWiseFFN(tf.keras.layers.Layer):
+    """
+    Position-wise feed-forward network layer.
+
+    Consists of two dense layers with customizable activation functions, weight initialization, non-linear projection,
+    and contextualized embeddings.
+
+    Parameters
+    ----------
+    input_hidden_units : int
+        Number of input hidden units.
+    output_hidden_units : int
+        Number of output hidden units.
+    activation : str or callable, optional
+        Activation function to use in the dense layers. Default is 'relu'.
+    init : str or callable, optional
+        Weight initialization strategy to use in the dense layers. Default is 'glorot_uniform'.
+    non_linear_proj : str, optional
+        Non-linear projection layer to use. Default is None, but you can also use 'glu' for a Gated Linear Unit or
+        'selu' for a Scaled Exponential Linear Unit. If non_linear_proj is not None, the output dimension will be twice
+        the input dimension.
+    contextualized_embeddings : `transformers.TFPreTrainedModel`, optional
+        Contextualized embedding model to use, such as BERT or ELMo. If provided, the input tensor will be passed through
+        the contextualized embedding model before being processed by the PositionWiseFFN layer.
+
+    Returns
+    -------
+    output : `tf.Tensor`
+        A tensor of shape `(batch size, number of time steps or sequence length in tokens, number of hidden units or
+        feature dimension)`.
+
+    Notes
+    -----
+    The Position-Wise Feed-Forward Layer is a type of feedforward layer consisting of two dense layers that apply to the
+    last dimension, which means the same dense layers are used for each position item in the sequence, so called
+    position-wise.
+
+    Examples
+    --------
+    >>> tf.random.set_seed(1)
+    >>> ffn = PositionWiseFFN(input_hidden_units=6, output_hidden_units=4, activation='tanh', init='he_uniform',
+                              non_linear_proj='glu', contextualized_embeddings=TFBertModel.from_pretrained('bert-base-uncased'))
+    >>> x = tf.ones((2, 3, 6))
+    >>> print(ffn(x))
+    tf.Tensor(
+    [[[ 0.51875997 -0.2624486  -0.79755557  1.5191057 ]
+      [ 0.51875997 -0.2624486  -0.79755557  1.5191057 ]
+      [ 0.51875997 -0.2624486  -0.79755557  1.5191057 ]]
+     [[ 0.51875997 -0.2624486  -0.79755557  1.5191057 ]
+      [ 0.51875997 -0.2624486  -0.79755557  1.5191057 ]
+      [ 0.51875997 -0.2624486  -0.79755557  1.5191057 ]]], shape=(2, 3, 4), dtype=float32)
+
+    References
+    ----------
+    Vaswani, A., Shazeer, N., Parmar, N., Uszkoreit, J., Jones, L., Gomez, A. N., Kaiser, L., & Polosukhin, I.
+    (2017). Attention Is All You Need. arXiv. https://doi.org/10.48550/arXiv.1706.03762
+    """
 
     def __init__(self, input_hidden_units, output_hidden_units, activation='relu', init='glorot_uniform',
                  non_linear_proj=None, contextualized_embeddings=None):
@@ -101,6 +156,7 @@ class PositionWiseFFN(tf.keras.layers.Layer):
         else:
             return self.dense2(self.dense1(x))
 
+
 os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
 if __name__ == '__main__':
     tf.random.set_seed(1)
@@ -109,4 +165,3 @@ if __name__ == '__main__':
                           non_linear_proj='glu')
     x = tf.ones((2, 3, 32))
     print(ffn(x))
-

--- a/transformerx/layers/positionwise_ffn.py
+++ b/transformerx/layers/positionwise_ffn.py
@@ -3,69 +3,110 @@ import os
 import tensorflow as tf
 
 
+# class PositionWiseFFN(tf.keras.layers.Layer):
+#     """Compute position-wise feed-forward network [1]_.
+#
+#     Consists of two dense layers with ReLU activation.
+#
+#     See Also
+#     --------
+#     transformerx.layers.transformer_encoder_block
+#     transformerx.layers.transformer_decoder_block
+#
+#     Notes
+#     -----
+#     Position-Wise Feed-Forward Layer is a type of feedforward layer consisting of two dense layers that applies to the
+#     last dimension, which means the same dense layers are used for each position item in the sequence, so called
+#     position-wise.
+#
+#     Parameters
+#     ----------
+#     input_hidden_units :
+#         Number of input hidden units
+#     output_hidden_units :
+#         Number of output hidden units
+#
+#     Returns
+#     -------
+#     Output :
+#         A tensor of shape (batch size, number of time steps or sequence length in tokens, number of hidden units or
+#         feature dimension)
+#
+#     Examples
+#     --------
+#     >>> tf.random.set_seed(1)
+#     >>> ffn = PositionWiseFFN(6, 4)
+#     >>> x = tf.ones((2, 3, 6))
+#     >>> print(ffn(x))
+#     tf.Tensor(
+#     [[[ 0.51875997 -0.2624486  -0.79755557  1.5191057 ]
+#       [ 0.51875997 -0.2624486  -0.79755557  1.5191057 ]
+#       [ 0.51875997 -0.2624486  -0.79755557  1.5191057 ]]
+#      [[ 0.51875997 -0.2624486  -0.79755557  1.5191057 ]
+#       [ 0.51875997 -0.2624486  -0.79755557  1.5191057 ]
+#       [ 0.51875997 -0.2624486  -0.79755557  1.5191057 ]]], shape=(2, 3, 4), dtype=float32)
+#
+#     References
+#     ----------
+#     .. [1] Vaswani, A., Shazeer, N., Parmar, N., Uszkoreit, J., Jones, L., Gomez, A. N., Kaiser, L., & Polosukhin, I.
+#     (2017). Attention Is All You Need. arXiv. https://doi.org/10.48550/arXiv.1706.03762
+#     """
+#
+#     def __init__(self, input_hidden_units, output_hidden_units):
+#         super().__init__()
+#         self.dense1 = tf.keras.layers.Dense(input_hidden_units)
+#         self.relu = tf.keras.layers.ReLU()
+#         self.dense2 = tf.keras.layers.Dense(output_hidden_units)
+#
+#     def call(self, x):
+#         # x.shape: (batch size, number of time steps or sequence length in tokens, number of hidden units or
+#         # feature dimension)
+#         return self.dense2(self.relu(self.dense1(x)))
+#
+#
+
+
+
 class PositionWiseFFN(tf.keras.layers.Layer):
-    """Compute position-wise feed-forward network [1]_.
 
-    Consists of two dense layers with ReLU activation.
-
-    See Also
-    --------
-    transformerx.layers.transformer_encoder_block
-    transformerx.layers.transformer_decoder_block
-
-    Notes
-    -----
-    Position-Wise Feed-Forward Layer is a type of feedforward layer consisting of two dense layers that applies to the
-    last dimension, which means the same dense layers are used for each position item in the sequence, so called
-    position-wise.
-
-    Parameters
-    ----------
-    input_hidden_units :
-        Number of input hidden units
-    output_hidden_units :
-        Number of output hidden units
-
-    Returns
-    -------
-    Output :
-        A tensor of shape (batch size, number of time steps or sequence length in tokens, number of hidden units or
-        feature dimension)
-
-    Examples
-    --------
-    >>> tf.random.set_seed(1)
-    >>> ffn = PositionWiseFFN(6, 4)
-    >>> x = tf.ones((2, 3, 6))
-    >>> print(ffn(x))
-    tf.Tensor(
-    [[[ 0.51875997 -0.2624486  -0.79755557  1.5191057 ]
-      [ 0.51875997 -0.2624486  -0.79755557  1.5191057 ]
-      [ 0.51875997 -0.2624486  -0.79755557  1.5191057 ]]
-     [[ 0.51875997 -0.2624486  -0.79755557  1.5191057 ]
-      [ 0.51875997 -0.2624486  -0.79755557  1.5191057 ]
-      [ 0.51875997 -0.2624486  -0.79755557  1.5191057 ]]], shape=(2, 3, 4), dtype=float32)
-
-    References
-    ----------
-    .. [1] Vaswani, A., Shazeer, N., Parmar, N., Uszkoreit, J., Jones, L., Gomez, A. N., Kaiser, L., & Polosukhin, I.
-    (2017). Attention Is All You Need. arXiv. https://doi.org/10.48550/arXiv.1706.03762
-    """
-
-    def __init__(self, input_hidden_units, output_hidden_units):
+    def __init__(self, input_hidden_units, output_hidden_units, activation='relu', init='glorot_uniform',
+                 non_linear_proj=None, contextualized_embeddings=None):
         super().__init__()
-        self.dense1 = tf.keras.layers.Dense(input_hidden_units)
-        self.relu = tf.keras.layers.ReLU()
-        self.dense2 = tf.keras.layers.Dense(output_hidden_units)
+        self.dense1 = tf.keras.layers.Dense(input_hidden_units, activation=activation, kernel_initializer=init)
+        self.non_linear_proj = non_linear_proj
+        if self.non_linear_proj == 'glu':
+            self.glu = tf.keras.layers.Dense(output_hidden_units * 2, activation='sigmoid', kernel_initializer=init)
+        elif self.non_linear_proj == 'selu':
+            self.selu = tf.keras.layers.Dense(output_hidden_units * 2, activation='selu', kernel_initializer=init)
+        else:
+            self.dense2 = tf.keras.layers.Dense(output_hidden_units, activation=activation, kernel_initializer=init)
+        self.contextualized_embeddings = contextualized_embeddings
 
     def call(self, x):
         # x.shape: (batch size, number of time steps or sequence length in tokens, number of hidden units or
         # feature dimension)
-        return self.dense2(self.relu(self.dense1(x)))
+        if self.contextualized_embeddings is not None:
+            bert_output = self.contextualized_embeddings(x)
+            x = bert_output[0]
+        if self.non_linear_proj == 'glu':
+            x = self.dense1(x)
+            split_units = x.shape[-1] // 2
+            return x[:, :, :split_units] * tf.keras.activations.sigmoid(self.glu(x[:, :, split_units:]))[:, :,
+                                           :split_units]
+        elif self.non_linear_proj == 'selu':
+            x = self.dense1(x)
+            split_units = x.shape[-1] // 2
+            return x[:, :, :split_units] * tf.keras.activations.sigmoid(self.selu(x[:, :, split_units:]))[:, :,
+                                           :split_units]
+        else:
+            return self.dense2(self.dense1(x))
 
 os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
 if __name__ == '__main__':
     tf.random.set_seed(1)
-    ffn = PositionWiseFFN(6, 4)
-    x = tf.ones((2, 3, 6))
+    # ffn = PositionWiseFFN(6, 4)
+    ffn = PositionWiseFFN(input_hidden_units=32, output_hidden_units=64, activation='tanh', init='he_uniform',
+                          non_linear_proj='glu')
+    x = tf.ones((2, 3, 32))
     print(ffn(x))
+


### PR DESCRIPTION
The new implementation, following options are added to the PositionwiseFNN class:

- Activation: specifies the activation function to use in the dense layers. The default is relu, but you can also use other activation functions such as sigmoid, tanh, or elu.

- Init: specifies the weight initialization strategy to use in the dense layers. The default is glorot_uniform, but you can also use other initialization strategies such as he_uniform, he_normal, or lecun_uniform.

- Non_linear_proj: specifies the non-linear projection layer to use. The default is None, but you can also use glu for a Gated Linear Unit or selu for a Scaled Exponential Linear Unit. Note that if non_linear_proj is not None, the output_hidden_units parameter will be ignored and the output dimension will be twice the input dimension.

- Contextualized_embeddings: specifies a contextualized embedding model to use, such as BERT or ELMo. If provided, the input tensor will be passed through the contextualized embedding model before being processed by the PositionWiseFFN layer.

- Dropout: adding dropout layers before or after the dense layers can help prevent overfitting and improve generalization.

This PR also updates the docstrings accordingly